### PR TITLE
Updates for rakudo 2017.08+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
-sudo: required
+language: perl6
+perl6:
+  - 2017.08
 env:
-  - PATH=$PATH:$HOME/.rakudobrew/bin PGDATABASE=test CACHED=$HOME/build_cache PGUSER=postgres
-before_install:
-  - sudo /etc/init.d/postgresql stop
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-  - sudo apt-get update
-  - sudo apt-get install postgresql-9.5
-  - sudo sed -i "s/port = ..../port = 5432/g" /etc/postgresql/9.5/main/postgresql.conf
-  - sudo cp -v /etc/postgresql/9.{4,5}/main/pg_hba.conf && sudo service postgresql restart 9.5
+  - PATH=$PATH:$HOME/.rakudobrew/bin PGDATABASE=test PGUSER=postgres
 install:
-  - ./install.sh
+  - rakudobrew build zef
+  - zef install --depsonly .
 before_script:
   - createdb test -U postgres
   - psql test -f schema.sql
-script:
-  - prove -Ilib -v -r --exec=perl6 t/
-cache:
-  directories:
-    - $HOME/.rakudobrew
+addons:
+  postgresql: "9.6"

--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
     "provides" : {
         "Utiaji" : "lib/Utiaji.pm"
     },
-    "depends" : [ "DBIish", "HTTP::Tinyish" ],
+    "depends" : [ "DBIish", "HTTP::Tinyish", "JSON::Fast" ],
     "resources" : [ ],
     "source-url" : "git://github.com/bduggan/utiaji.git"
 }

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ It is written in Perl 6.
 
 Install
 =======
+* Install [Perl 6](https://perl6.org/downloads/) and [zef](https://github.com/ugexe/zef).
 ```
 createdb utiaji
 psql utiaji -f schema.sql
-./install.sh
+zef install --deps-only .
 ```
 
 Run
@@ -22,8 +23,11 @@ Run
 PGDATABASE=utiaji ./bin/utiaji
 ```
 
-Discuss
+Demo
 ===
 A live installation is at <http://utiaji.org>.
-There's a mailing list at <http://groups.google.com/group/utiaji>.
+
+THANKS
+===
+* to Ryan Hinkel for all the React help.
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,6 @@ dependencies:
     - psql test -f schema.sql
   override:
     - ./install.sh
-  cache_directories:
-    - ../.rakudobrew
 test:
   override:
     - prove -Ilib -v -r --exec=perl6 t/

--- a/install.sh
+++ b/install.sh
@@ -1,29 +1,10 @@
 #!/bin/bash -ex
 
-version=2016.05
+version=2017.08
 
 export PATH=$HOME/.rakudobrew/bin:$PATH
 
-deps() {
-    panda --installed list | grep -q DBIish || panda --notests install DBIish
-    panda --installed list | grep -q 'HTTP::Tinyish' || panda install HTTP::Tinyish
-}
-
-if [ -x $HOME/.rakudobrew/bin/perl6 ]; then
-    if $HOME/.rakudobrew/bin/perl6 --version | grep -q "$version"; then
-        echo "using $version"
-        rakudobrew global $version
-        rakudobrew rehash
-        rakudobrew build-panda
-        deps
-        exit
-    fi
-fi
-
-echo "building $version"
-
-rm -rf $HOME/.rakudobrew
 git clone https://github.com/tadzik/rakudobrew.git $HOME/.rakudobrew
 rakudobrew build moar $version
-rakudobrew build-panda
-deps
+rakudobrew build-zef
+zef install --depsonly .

--- a/lib/Utiaji/Template.pm6
+++ b/lib/Utiaji/Template.pm6
@@ -2,6 +2,9 @@ unit class Utiaji::Template;
 use Utiaji::Log;
 use JSON::Fast;
 
+# TODO, types are used in templates, need to import this
+use Utiaji::Model::Pim;
+
 has $.raw;
 has $.parsed;
 has $.cache-key;

--- a/templates/pim/wiki.html.ep6
+++ b/templates/pim/wiki.html.ep6
@@ -1,4 +1,4 @@
-%| :$page, *%args
+%| Page :$page, *%args
 
 ▶== include $app, 'header', |%args;
 

--- a/templates/pim/wiki.html.ep6
+++ b/templates/pim/wiki.html.ep6
@@ -1,4 +1,4 @@
-%| Page :$page, *%args
+%| :$page, *%args
 
 ▶== include $app, 'header', |%args;
 


### PR DESCRIPTION
These changes deprecate the use of panda in favor of zef, and remove the custom install script in favor of zef's dependency management.